### PR TITLE
bugfix: HandleAppendEntriesRequest

### DIFF
--- a/raft.tla
+++ b/raft.tla
@@ -354,7 +354,8 @@ HandleAppendEntriesRequest(i, j, m) ==
              /\ LET index == m.mprevLogIndex + 1
                 IN \/ \* already done with request
                        /\ \/ m.mentries = << >>
-                          \/ /\ Len(log[i]) >= index
+                          \/ /\ m.mentries /= << >>
+                             /\ Len(log[i]) >= index
                              /\ log[i][index].term = m.mentries[1].term
                           \* This could make our commitIndex decrease (for
                           \* example if we process an old, duplicated request),
@@ -369,7 +370,7 @@ HandleAppendEntriesRequest(i, j, m) ==
                                  msource         |-> i,
                                  mdest           |-> j],
                                  m)
-                       /\ UNCHANGED <<serverVars, logVars>>
+                       /\ UNCHANGED <<serverVars, log>>
                    \/ \* conflict: remove 1 entry
                        /\ m.mentries /= << >>
                        /\ Len(log[i]) >= index


### PR DESCRIPTION
There are two bugs in `HandleAppendEntriesRequest`:
1. even a `appendEntries` with no entries will go to `log[i][index].term = m.mentries[1].term`(line 358);
2. the action expr `commitIndex' = [commitIndex EXCEPT ![i] = m.mcommitIndex]`(line 362) changes `commitIndex`, but commitIndex is declared wouldn't change by `UNCHANGED <<serverVars, logVars>>`(line 372).